### PR TITLE
system_signal

### DIFF
--- a/src/M_system.f90
+++ b/src/M_system.f90
@@ -33,7 +33,7 @@
 !!    system_gethostname, system_getpid, system_getppid, system_setsid, &
 !!    system_getsid, system_getuid, system_uname
 !!    ! SIGNALS
-!!    use M_system, only : system_kill
+!!    use M_system, only : system_kill,system_signal
 !!    ! RANDOM NUMBERS
 !!    use M_system, only : system_rand, system_srand
 !!    ! PROCESS INFORMATION
@@ -165,6 +165,7 @@ public :: system_getgid, system_getegid  ! return group ID
 public :: system_setsid
 public :: system_getsid
 public :: system_kill                    ! (pid, signal) kill process (defaults: pid=0, signal=SIGTERM)
+public :: system_signal                  ! (signal,handler) install signal handler subroutine
 
 public :: system_errno
 public :: system_perror
@@ -1117,7 +1118,95 @@ integer(kind=c_int),parameter           :: R_OK=4
 integer(kind=c_int),parameter           :: W_OK=2
 integer(kind=c_int),parameter           :: X_OK=1
 !===================================================================================================================================
+!()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
+!===================================================================================================================================
+abstract interface                       !  mold for signal handler to be installed by system_handler
+   subroutine handler(signum)
+   integer :: signum
+   end subroutine handler
+end interface
+procedure(handler), pointer :: handler_ptr => null()    ! this pointer shall point to the signal handler
+!===================================================================================================================================
 contains
+!===================================================================================================================================
+!()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
+!===================================================================================================================================
+!>
+!!##NAME
+!!    system_signal(3f) - [M_system] install a signal handler
+!!    (LICENSE:PD)
+!!
+!!##SYNOPSIS
+!!
+!!    subroutine system_signal(sig,handler)
+!!
+!!       integer,intent(in) :: sig
+!!       interface
+!!         subroutine handler(signum)
+!!         integer :: signum
+!!         end subroutine handler
+!!       end interface
+!!
+!!##DESCRIPTION
+!!
+!!       Calling system_signal(NUMBER, HANDLER) causes user-defined subroutine 
+!!       HANDLER to be executed when the signal NUMBER is caught. The same sub-
+!!       routine HANDLER maybe installed to handle different signals. HANDLER
+!!       takes only one integer argument which is assigned the signal number that
+!!       is caught. See sample program below for illustration.
+!!
+!!       Note that the signals SIGKILL and SIGSTOP cannot be handled this way.
+!!
+!!       [Compare signal(2) and the GNU extension signal in gfortran.]
+
+!!##EXAMPLE
+!!
+!!   Sample program:
+!!
+!!    program demo_system_signal
+!!    use M_system, only : system_signal
+!!    implicit none
+!!    call system_signal(2,handler)
+!!    call system_signal(3,handler)
+!!    write(*,*)'Press Ctrl+C to send SIGINT.'
+!!    do
+!!    enddo
+!!
+!!    contains
+!!
+!!    subroutine handler(signum)
+!!      integer :: signum
+!!      if(signum==2)then
+!!          write(*,*)'Caught SIGINT. Try Ctrl+\ now.'
+!!      else
+!!          write(*,*)'Caught SIGQUIT.' ; STOP
+!!      endif
+!!    end subroutine handler
+!!    end program demo_system_signal
+
+subroutine system_signal(signum,handler_routine)
+integer, intent(in) :: signum
+procedure(handler):: handler_routine
+type(c_funptr) :: ret,c_handler
+
+interface
+   function c_signal(signal, sighandler) bind(c,name='signal')
+   import :: c_int,c_funptr 
+   integer(c_int), value, intent(in) :: signal
+   type(c_funptr), value, intent(in) :: sighandler
+   type(c_funptr) :: c_signal
+   end function c_signal
+end interface
+
+handler_ptr => handler_routine
+c_handler=c_funloc(f_handler)
+ret=c_signal(signum,c_handler)
+end subroutine system_signal
+
+subroutine f_handler(signum) bind(c)
+integer(c_int), intent(in), value :: signum
+call handler_ptr(signum)
+end subroutine f_handler
 !===================================================================================================================================
 !()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
 !===================================================================================================================================

--- a/src/M_system.f90
+++ b/src/M_system.f90
@@ -33,7 +33,7 @@
 !!    system_gethostname, system_getpid, system_getppid, system_setsid, &
 !!    system_getsid, system_getuid, system_uname
 !!    ! SIGNALS
-!!    use M_system, only : system_kill
+!!    use M_system, only : system_kill,system_signal
 !!    ! RANDOM NUMBERS
 !!    use M_system, only : system_rand, system_srand
 !!    ! PROCESS INFORMATION
@@ -165,6 +165,7 @@ public :: system_getgid, system_getegid  ! return group ID
 public :: system_setsid
 public :: system_getsid
 public :: system_kill                    ! (pid, signal) kill process (defaults: pid=0, signal=SIGTERM)
+public :: system_signal                  ! (signal,handler) install signal handler subroutine
 
 public :: system_errno
 public :: system_perror
@@ -1117,7 +1118,91 @@ integer(kind=c_int),parameter           :: R_OK=4
 integer(kind=c_int),parameter           :: W_OK=2
 integer(kind=c_int),parameter           :: X_OK=1
 !===================================================================================================================================
+!()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
+!===================================================================================================================================
+abstract interface                       !  mold for signal handler to be installed by system_handler
+   subroutine handler(signum)
+   integer :: signum
+   end subroutine handler
+end interface
+procedure(handler), pointer :: handler_ptr => null()    ! this pointer shall point to the signal handler
+!===================================================================================================================================
 contains
+!===================================================================================================================================
+!()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
+!===================================================================================================================================
+!>
+!!##NAME
+!!    system_signal(3f) - [M_system] install a signal handler
+!!    (LICENSE:PD)
+!!
+!!##SYNOPSIS
+!!
+!!    subroutine system_signal(sig,handler)
+!!
+!!       integer,intent(in) :: sig
+!!       interface
+!!         subroutine handler(signum)
+!!         integer :: signum
+!!         end subroutine handler
+!!       end interface
+!!
+!!##DESCRIPTION
+!!
+!!       Calling system_signal(SIGNAL, HANDLER) causes user-defined subroutine 
+!!       HANDLER to be executed. The subroutine takes only one integer argument 
+!!       which is given the value of SIGNAL. See sample program below.
+!!       Note that the signals SIGKILL and SIGSTOP cannot be handled this way.
+!!       Compare signal(2).
+
+!!##EXAMPLE
+!!
+!!   Sample program:
+!!
+!!    program demo_system_signal
+!!    use M_system, only : system_signal
+!!    implicit none
+!!    call system_signal(2,handler)
+!!    call system_signal(3,handler)
+!!    write(*,*)'Press Ctrl+C to send SIGINT.'
+!!    do
+!!    enddo
+!!
+!!    contains
+!!
+!!    subroutine handler(signum)
+!!      integer :: signum
+!!      if(signum==2)then
+!!          write(*,*)'Caught SIGINT. Try Ctrl+\ now.'
+!!      else
+!!          write(*,*)'Caught SIGQUIT.' ; STOP
+!!      endif
+!!    end subroutine handler
+!!    end program demo_system_signal
+
+subroutine system_signal(signum,handler_routine)
+integer, intent(in) :: signum
+procedure(handler):: handler_routine
+type(c_funptr) :: ret,c_handler
+
+interface
+   function c_signal(signal, sighandler) bind(c,name='signal')
+   import :: c_int,c_funptr 
+   integer(c_int), value, intent(in) :: signal
+   type(c_funptr), value, intent(in) :: sighandler
+   type(c_funptr) :: c_signal
+   end function c_signal
+end interface
+
+handler_ptr => handler_routine
+c_handler=c_funloc(f_handler)
+ret=c_signal(signum,c_handler)
+end subroutine system_signal
+
+subroutine f_handler(signum) bind(c)
+integer(c_int), intent(in), value :: signum
+call handler_ptr(signum)
+end subroutine f_handler
 !===================================================================================================================================
 !()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()!
 !===================================================================================================================================


### PR DESCRIPTION
Added system_signal (sig , handler) subroutine that installs handler for signal number sig.

I needed a few things to implement this: an abstract interface, a procedure pointer and a fortran-c-interoperable subroutine f_handler, apart from the all important wrapper for signal(2) within system_signal.

The wrapper for signal(2) needs a signal handler with fortran-c-interoperable interface. We, however, need to hide this bind(c) requirement from the user and make life simpler for him/her. Hence, the following strategy is used.

User simply writes a subroutine that takes an integer argument (see handler). The procedure pointer then points to this subroutine as system_signal is called. The interoperable procedure f_handler is designed to call whatever subroutine this pointer points to. Finally, system_signal installs f_handler through the c-function signal.

Tested with the sample program described. Works for me!